### PR TITLE
Sort notes by updated date descending.

### DIFF
--- a/plugin/conn.py
+++ b/plugin/conn.py
@@ -20,7 +20,7 @@ def GeeknoteGetDefaultNotebook():
     return noteStore.getDefaultNotebook(authToken)
 
 def GeeknoteGetNotes(searchWords=""):
-    filter = NoteStore.NoteFilter(order = Types.NoteSortOrder.CREATED)
+    filter = NoteStore.NoteFilter(order = Types.NoteSortOrder.UPDATED)
     filter.words = searchWords
 
     meta = NoteStore.NotesMetadataResultSpec()

--- a/plugin/explorer.py
+++ b/plugin/explorer.py
@@ -86,7 +86,6 @@ class NotebookNode(Node):
             del self.children[:]
 
             notes = self.getNotes()
-            notes.sort(key=lambda n: n.title)
 
             for note in notes:
                 self.addNote(note)


### PR DESCRIPTION
Matches the Evernote client and web interface, and stops asking for one sort and then resorting in-memory.

(Also, it's just plain more useful to put things the user has recently touched first rather than always displaying some four-year old clipping that happens to start with "Aardvark".)
