### PR TITLE
suffix .markdown to enable ft setting

### DIFF
--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,9 +1,16 @@
+#!/usr/bin/env python
 import vim
 import tempfile
 
 def createTempFile(**kwargs):
     if 'prefix' not in kwargs:
         kwargs['prefix'] = '__Geeknote__'
+
+    if 'suffix' not in kwargs:
+        geeknoteformat = 'markdown'
+        if int(vim.eval('exists("g:GeeknoteFormat")')):
+            geeknoteformat = vim.eval('g:GeeknoteFormat')
+        kwargs['suffix'] = '.{}'.format(geeknoteformat)
 
     if 'dir' not in kwargs:
         if int(vim.eval('exists("g:GeeknoteScratchDirectory")')):

--- a/plugin/view.py
+++ b/plugin/view.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import vim
 
 from enml  import *
@@ -178,8 +179,8 @@ def GeeknoteOpenNote(note):
     # TODO: Figure out why setting the 'syntax' buffer option alone does not
     #       enable syntax highlighting and why setlocal is needed instead.
     #
-    vim.current.buffer.options['filetype'] = 'markdown'
-    vim.command('setlocal syntax=markdown')
+    # vim.current.buffer.options['filetype'] = 'markdown'
+    # vim.command('setlocal syntax=markdown')
 
     # Now restore the original window.
     setActiveWindow(origWin)


### PR DESCRIPTION
The default `filetype` should be enabled via append suffix instead of setting it directly in vim. At least there two kinds of naming convention among markdown plugins -- `markdown` or `mkd`. By appending suffix, it give the plugins using the `mkd` naming convention a chance to work around, for example, by adding a line in `.vimrc`

```
autocmd BufRead, BufNewFile *.markdown set ft=mkd
```

Otherwise, you have to manually setting the `filetype` option every time to enable the `mkd` plugins.
